### PR TITLE
Introduce needed_other_repositories

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -18,7 +18,7 @@
             - FreydCategoriesForCAP
             - Algebroids
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - Toposes
@@ -73,7 +73,7 @@
           doc_additional_latex_preamble: |
             \usepackage{mathtools}
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - CategoryConstructor
@@ -109,7 +109,7 @@
             - SubcategoriesForCAP
             - LazyCategories
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - Toposes
@@ -144,7 +144,7 @@
             \DeclareUnicodeCharacter{22C3}{\ensuremath{\bigcup}}
             \DeclareUnicodeCharacter{2229}{\ensuremath{\cap}}
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - Toposes
@@ -171,7 +171,7 @@
           doc_additional_latex_preamble: |
             \usepackage{mathtools}
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - CategoryConstructor
@@ -197,7 +197,7 @@
           doc_additional_latex_preamble: |
             \usepackage{mathtools}
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - CategoryConstructor
@@ -227,7 +227,7 @@
           description: "Categories of functors"
           doc_additional_latex_preamble: |
             \usepackage{mathtools}
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - CategoryConstructor
@@ -257,7 +257,7 @@
           doc_additional_latex_preamble: |
             \usepackage{mathtools}
           tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - CategoryConstructor
@@ -290,11 +290,11 @@
             \DeclareUnicodeCharacter{03C1}{\ensuremath{\rho}}
             \DeclareUnicodeCharacter{03BD}{\ensuremath{\nu}}
             \DeclareUnicodeCharacter{03C7}{\ensuremath{\chi}}
-        ci_additional_packages_to_clone:
-          - homalg_project
-          - CAP_project
-          - InfiniteLists
-          - GradedCategories
+          needed_other_repositories:
+            - homalg_project
+            - CAP_project
+            - InfiniteLists
+            - GradedCategories
         ci_ubuntu_additional_apt_packages:
           - texlive-fonts-extra
 
@@ -310,10 +310,11 @@
           name: GradedCategories
           description: "Graded closures of categories"
           has_HOMALG_IO: true
-        ci_additional_packages_to_clone:
-          - homalg_project
-          - CAP_project
-          - InfiniteLists
+          needed_other_repositories:
+            - homalg_project
+            - CAP_project
+            - InfiniteLists
+        ci_additional_repositories:
           - InternalModules
         ci_additional_packages_to_test:
           - InternalModules
@@ -355,10 +356,10 @@
         package:
           name: FinSetsForCAP
           description: "The elementary topos of (skeletal) finite sets"
-        ci_additional_packages_to_clone:
-          - homalg_project
-          - CAP_project
-          - Toposes
+          needed_other_repositories:
+            - homalg_project
+            - CAP_project
+            - Toposes
 
 - name: FinGSetsForCAP
   hosts: FinGSetsForCAP
@@ -414,11 +415,11 @@
             \DeclareMathSymbol{\lsb@l}{\mathalpha}{letters}{`l}
             \lowercase{\gdef~{\ifnum\the\mathgroup=\m@ne \ell \else \lsb@l \fi}}%
             \endgroup
-        ci_additional_packages_to_clone:
-          - homalg_project
-          - CAP_project
-          - Toposes
-          - FinSetsForCAP
+          needed_other_repositories:
+            - homalg_project
+            - CAP_project
+            - Toposes
+            - FinSetsForCAP
         ci_ubuntu_additional_apt_packages:
           - texlive-science
           - texlive-fonts-extra
@@ -496,7 +497,7 @@
             tests_additional_packages_to_load:
               - DerivedCategories
             tests_only_basic: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
           - CAP_project
           - Toposes
@@ -585,7 +586,7 @@
               - Algebroids
             tests_only_basic: true
             docu_only: true
-        ci_additional_packages_to_clone:
+        ci_additional_repositories:
           - homalg_project
         ci_ubuntu_additional_apt_packages:
           - texlive-science

--- a/tasks/meta_package.yml
+++ b/tasks/meta_package.yml
@@ -31,6 +31,20 @@
   vars:
     package: "{{ meta_package_enriched }}"
 
+- name: Initialize ci_additional_repositories_enriched
+  set_fact:
+    ci_additional_repositories_enriched: "{{ ci_additional_repositories | default([]) }}"
+
+- name: Prepend needed_other_repositories of subpackages to ci_additional_repositories_enriched
+  set_fact:
+    ci_additional_repositories_enriched: "{{ (item.needed_other_repositories | default([])) + ci_additional_repositories_enriched }}"
+  loop: "{{ subpackages }}"
+  no_log: true
+
+- name: Remove duplicates from ci_additional_repositories_enriched
+  set_fact:
+    ci_additional_repositories_enriched: "{{ ci_additional_repositories_enriched | unique }}"
+
 - import_tasks: tasks/ci.yml
   vars:
     package: "{{ meta_package_enriched }}"

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -14,6 +14,7 @@
   vars:
     package: "{{ package_enriched }}"
     pdf_doc_packages: "{{ [] if gh_pages_response.status == 200 else [ package ] }}"
+    ci_additional_repositories_enriched: "{{ (package.needed_other_repositories | default([])) + (ci_additional_repositories | default([])) }}"
 
 - import_tasks: tasks/GitHubPages.yml
   vars:

--- a/templates/README.md_HEADER.j2
+++ b/templates/README.md_HEADER.j2
@@ -9,3 +9,14 @@
 {% else %}
 | [![][docs-img]][docs-url] | [![][tests-img]][tests-url] [![][codecov-img]][codecov-url] |
 {% endif %}
+{% if package.needed_other_repositories is defined %}
+
+### Dependencies
+
+To obtain current versions of all dependencies, clone the following repositories:
+{% for repo in package.needed_other_repositories %}
+{{ loop.index }}. **{{ repo }}**: https://github.com/homalg-project/{{ repo }}
+{% endfor %}
+
+---
+{% endif %}

--- a/templates/Tests.yml.j2
+++ b/templates/Tests.yml.j2
@@ -29,7 +29,7 @@ jobs:
           sudo apt dist-upgrade -y
           sudo apt install -y texlive-latex-extra{% for apt_package in (ci_ubuntu_additional_apt_packages | default([ ])) %} {{ apt_package }}{% endfor %}
           git clone --depth 1 https://github.com/gap-packages/AutoDoc.git
-        {%- for additional_package in (ci_additional_packages_to_clone | default([ ])) %}
+        {%- for additional_package in ci_additional_repositories_enriched %}
           git clone --depth 1 https://github.com/homalg-project/{{ additional_package }}.git
         {%- endfor %}
           # set SOURCE_DATE_EPOCH for reproducible PDFs


### PR DESCRIPTION
Fixes #26

I have split `ci_additional_packages_to_clone` into:

1. `needed_other_repositories` (like NeededOtherPackages, but for repositories): a per-(sub)package key
2. `ci_additional_repositories`: a top-level key

`needed_other_repositories` is used to render a list of dependencies in the readme, see https://github.com/zickgraf/GradedCategories/tree/ansible for an example.