### PR TITLE
Add unmodified version of GPLv2 and add license identifiers to source files

### DIFF
--- a/files/LICENSE
+++ b/files/LICENSE
@@ -1,24 +1,12 @@
-{{ package.name }} is free software; you can redistribute and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or (at
-your opinion) any later version.
-
-{{ package.name }} is distributed in the hope that it will be useful, 
-but WITHOUT ANY WARRANTY; without even the implied warranty of 
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-General Public License for more details.
-
-Version 2 of the GNU General Public License follows.
-
-		    GNU GENERAL PUBLIC LICENSE
-		       Version 2, June 1991
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
-			    Preamble
+                            Preamble
 
   The licenses for most software are designed to take away your
 freedom to share and change it.  By contrast, the GNU General Public
@@ -67,8 +55,8 @@ patent must be licensed for everyone's free use or not licensed at all.
 
   The precise terms and conditions for copying, distribution and
 modification follow.
-
-		    GNU GENERAL PUBLIC LICENSE
+
+                    GNU GENERAL PUBLIC LICENSE
    TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
   0. This License applies to any program or other work which contains
@@ -122,7 +110,7 @@ above, provided that you also meet all of these conditions:
     License.  (Exception: if the Program itself is interactive but
     does not normally print such an announcement, your work based on
     the Program is not required to print an announcement.)
-
+
 These requirements apply to the modified work as a whole.  If
 identifiable sections of that work are not derived from the Program,
 and can be reasonably considered independent and separate works in
@@ -180,7 +168,7 @@ access to copy from a designated place, then offering equivalent
 access to copy the source code from the same place counts as
 distribution of the source code, even though third parties are not
 compelled to copy the source along with the object code.
-
+
   4. You may not copy, modify, sublicense, or distribute the Program
 except as expressly provided under this License.  Any attempt
 otherwise to copy, modify, sublicense or distribute the Program is
@@ -237,7 +225,7 @@ impose that choice.
 
 This section is intended to make thoroughly clear what is believed to
 be a consequence of the rest of this License.
-
+
   8. If the distribution and/or use of the Program is restricted in
 certain countries either by patents or by copyrighted interfaces, the
 original copyright holder who places the Program under this License
@@ -267,7 +255,7 @@ make exceptions for this.  Our decision will be guided by the two goals
 of preserving the free status of all derivatives of our free software and
 of promoting the sharing and reuse of software generally.
 
-			    NO WARRANTY
+                            NO WARRANTY
 
   11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
 FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
@@ -289,5 +277,63 @@ YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
 PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGES.
 
-		     END OF TERMS AND CONDITIONS
-
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Ty Coon>, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/tasks/package_common.yml
+++ b/tasks/package_common.yml
@@ -76,7 +76,7 @@
     path: "{{ pkg_dir }}/{{ package.path }}/init.g"
     regexp: "\\A(.*\n){5}"
     replace: |
-      #
+      # SPDX-License-Identifier: GPL-2.0-or-later
       # {{ package.name }}: {{ package.description }}
       #
       # Reading the declaration part of the package.
@@ -87,7 +87,7 @@
     path: "{{ pkg_dir }}/{{ package.path }}/read.g"
     regexp: "\\A(.*\n){5}"
     replace: |
-      #
+      # SPDX-License-Identifier: GPL-2.0-or-later
       # {{ package.name }}: {{ package.description }}
       #
       # Reading the implementation part of the package.
@@ -98,7 +98,7 @@
     path: "{{ pkg_dir }}/{{ package.path }}/PackageInfo.g"
     regexp: "\\A(.*\n){8}"
     replace: |
-      #
+      # SPDX-License-Identifier: GPL-2.0-or-later
       # {{ package.name }}: {{ package.description }}
       #
       # This file contains package meta data. For additional information on
@@ -112,7 +112,7 @@
     path: "{{ cur_path }}"
     regexp: "\\A(.*\n){5}"
     replace: |
-      #
+      # SPDX-License-Identifier: GPL-2.0-or-later
       # {{ package.name }}: {{ package.description }}
       #
       # Declarations
@@ -126,7 +126,7 @@
     path: "{{ cur_path }}"
     regexp: "\\A(.*\n){5}"
     replace: |
-      #
+      # SPDX-License-Identifier: GPL-2.0-or-later
       # {{ package.name }}: {{ package.description }}
       #
       # Implementations
@@ -148,8 +148,8 @@
     tests_packages_to_load: "{{ [ package.name ] + (package.tests_additional_packages_to_load | default([])) }}"
 
 - name: LICENSE
-  template:
-    src: LICENSE.j2
+  copy:
+    src: LICENSE
     dest: "{{ pkg_dir }}/{{ package.path }}/LICENSE"
 
 - name: makedoc.g

--- a/templates/000_LoadPackage.tst.j2
+++ b/templates/000_LoadPackage.tst.j2
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # {{ package.name }}: {{ package.description }}
 #
 # This file tests if the package can be loaded without errors or warnings.

--- a/templates/makedoc.g.j2
+++ b/templates/makedoc.g.j2
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # {{ package.name }}: {{ package.description }}
 #
 # This file is a script which compiles the package manual.

--- a/templates/makedoc_with_overfull_hbox_warnings.g.j2
+++ b/templates/makedoc_with_overfull_hbox_warnings.g.j2
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # {{ package.name }}: {{ package.description }}
 #
 # This file is a script which compiles the package manual and prints overfull hbox warnings.

--- a/templates/testall.g.j2
+++ b/templates/testall.g.j2
@@ -1,4 +1,4 @@
-#
+# SPDX-License-Identifier: GPL-2.0-or-later
 # {{ package.name }}: {{ package.description }}
 #
 # This file runs package tests. It is also referenced in the package


### PR DESCRIPTION
Fixes #27

Adding license identifiers is what the linux kernel does: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=5fd54ace4721fc5ce2bb5aef6318fcf17f421460
> The SPDX identifier is a legally binding shorthand, which can be used
instead of the full boiler plate text.