### PR TITLE
Generate package overview for homalg-project.github.io

### DIFF
--- a/hosts
+++ b/hosts
@@ -15,3 +15,4 @@ FinSetsForCAP
 FinGSetsForCAP
 CAP_project
 homalg_project
+homalg-project.github.io

--- a/site.yml
+++ b/site.yml
@@ -637,3 +637,84 @@
           - texlive-science
           - time
           - python-pathlib
+
+- name: homalg-project.github.io
+  hosts: homalg-project.github.io
+  connection: local
+  tasks:
+    - import_tasks: tasks/homalg-project.github.io.yml
+      vars:
+        packages:
+          - meta_package:
+              name: CAP_project
+              description: Categories, Algorithms, and Programming.
+            subpackages:
+              - name: CAP
+              - name: ActionsForCAP
+              - name: AttributeCategoryForCAP
+              - name: CompilerForCAP
+              - name: ComplexesAndFilteredObjectsForCAP
+              - name: DeductiveSystemForCAP
+              - name: FreydCategoriesForCAP
+              - name: GeneralizedMorphismsForCAP
+              - name: GradedModulePresentationsForCAP
+              - name: GroupRepresentationsForCAP
+              - name: HomologicalAlgebraForCAP
+              - name: InternalExteriorAlgebraForCAP
+              - name: LinearAlgebraForCAP
+              - name: ModulePresentationsForCAP
+              - name: ModulesOverLocalRingsForCAP
+              - name: MonoidalCategories
+              - name: ToricSheaves
+            used_by:
+              - name: Algebroids
+              - name: CategoryConstructor
+              - name: CategoriesWithAmbientObjects
+              - name: CatReps
+              - name: FinSetsForCAP
+              - name: FinGSetsForCAP
+              - name: FunctorCategories
+              - name: GradedCategories
+              - name: IntrinsicCategories
+              - name: IntrinsicModules
+              - name: InternalModules
+              - name: LazyCategories
+              - name: Locales
+              - name: QPA2
+              - name: SubcategoriesForCAP
+              - name: Toposes
+              - name: WrapperCategories
+              - name: ZariskiFrames
+          - meta_package:
+              name: homalg_project
+              description: The homalg project is a multi-author multi-package open source software project for constructive homological algebra.
+            subpackages:
+              - name: homalg
+              - name: 4ti2Interface
+              - name: ExamplesForHomalg
+              - name: Gauss
+              - name: GaussForHomalg
+              - name: GradedModules
+              - name: GradedRingForHomalg
+              - name: HomalgToCAS
+              - name: IO_ForHomalg
+              - name: LocalizeRingForHomalg
+              - name: MatricesForHomalg
+              - name: Modules
+              - name: RingsForHomalg
+              - name: SCO
+              - name: ToolsForHomalg
+            used_by:
+              - name: OscarForHomalg
+              - name: alcove
+              - name: AlgebraicThomas
+              - name: ArangoDBInterface
+              - name: Blocks
+              - name: D-Modules
+              - name: LessGenerators
+              - name: LoopIntegrals
+              - name: MatroidGeneration
+              - name: NConvex
+              - name: ParallelizedIterators
+              - name: PrimaryDecomposition
+              - name: Sheaves

--- a/tasks/homalg-project.github.io.yml
+++ b/tasks/homalg-project.github.io.yml
@@ -1,0 +1,8 @@
+---
+- name: Import meta package
+  include_tasks: tasks/homalg-project.github.io_package.yml
+  vars:
+    meta_package: "{{ item.meta_package }}"
+    subpackages: "{{ item.subpackages }}"
+    used_by: "{{ item.used_by }}"
+  loop: "{{ packages }}"

--- a/tasks/homalg-project.github.io_package.yml
+++ b/tasks/homalg-project.github.io_package.yml
@@ -1,0 +1,24 @@
+---
+- name: Create header
+  blockinfile:
+    path: ~/index.md
+    marker: "<!-- {mark} {{ meta_package.name }} HEADER -->"
+    block: |
+      # {{ meta_package.name }}
+      
+      {{ meta_package.description }}
+      
+      | Build Status | Code Coverage |
+      | ------------ | ------------- |
+      | [![Build Status](https://github.com/homalg-project/{{ meta_package.name }}/workflows/Tests/badge.svg)](https://github.com/homalg-project/{{ meta_package.name }}/actions?query=workflow%3ATests) | {# -#}
+        [![Code Coverage](https://codecov.io/gh/homalg-project/{{ meta_package.name }}/branch/master/graph/badge.svg)](https://codecov.io/gh/homalg-project/{{ meta_package.name }}) |
+
+- name: Include table for subpackages
+  include_tasks: tasks/homalg-project.github.io_subpackage_table.yml
+  vars:
+    packages: "{{ subpackages }}"
+
+- name: Include table for depending packages
+  include_tasks: tasks/homalg-project.github.io_used_by_table.yml
+  vars:
+    packages: "{{ used_by }}"

--- a/tasks/homalg-project.github.io_subpackage_table.yml
+++ b/tasks/homalg-project.github.io_subpackage_table.yml
@@ -1,0 +1,48 @@
+---
+- name: Get PackageInfos
+  uri:
+    url: https://raw.githubusercontent.com/homalg-project/{{ meta_package.name }}/master/{{ package.name }}/PackageInfo.g
+    return_content: yes
+  register: PackageInfo_responses
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Check if HTML docu is available
+  uri:
+    url: https://homalg-project.github.io/{{ meta_package.name }}/{{ package.name }}/doc/chap0_mj.html
+  register: HTML_responses
+  failed_when: HTML_responses.status is not defined
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Check if PDF docu is available
+  uri:
+    url: https://raw.githubusercontent.com/homalg-project/{{ meta_package.name }}/doc/{{ package.name }}.pdf
+  register: PDF_responses
+  failed_when: PDF_responses.status is not defined
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Initialize packages_enriched
+  set_fact:
+    packages_enriched: "{{ [] }}"
+
+- name: Set packages_enriched
+  set_fact:
+    packages_enriched: "{{ packages_enriched + [ zipped[0] | combine( { 'description': zipped[1].content | regex_search('Subtitle := \"[^\"]*') | replace('Subtitle := \"', ''), 'status': zipped[1].content | regex_search('Status := \"[^\"]*') | replace('Status := \"', ''), 'has_html_docu': zipped[2].status == 200, 'has_pdf_docu': zipped[3].status == 200 } ) ] }}"
+  loop: "{{ packages | zip(PackageInfo_responses.results, HTML_responses.results, PDF_responses.results) | list }}"
+  loop_control:
+    loop_var: zipped
+  no_log: true
+
+- name: Create subpackage table
+  blockinfile:
+    path: ~/index.md
+    marker: "<!-- {mark} {{ meta_package.name }} SUBPACKAGES -->"
+    block: "{{ lookup('template', 'templates/homalg-project.github.io_subpackage_table.j2') }}"

--- a/tasks/homalg-project.github.io_used_by_table.yml
+++ b/tasks/homalg-project.github.io_used_by_table.yml
@@ -1,0 +1,48 @@
+---
+- name: Get PackageInfos
+  uri:
+    url: https://raw.githubusercontent.com/homalg-project/{{ package.name }}/master/PackageInfo.g
+    return_content: yes
+  register: PackageInfo_responses
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Check if HTML docu is available
+  uri:
+    url: https://homalg-project.github.io/{{ package.name }}/doc/chap0_mj.html
+  register: HTML_responses
+  failed_when: HTML_responses.status is not defined
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Check if PDF docu is available
+  uri:
+    url: https://raw.githubusercontent.com/homalg-project/{{ package.name }}/doc/{{ package.name }}.pdf
+  register: PDF_responses
+  failed_when: PDF_responses.status is not defined
+  check_mode: no
+  loop: "{{ packages }}"
+  loop_control:
+    loop_var: package
+
+- name: Initialize packages_enriched
+  set_fact:
+    packages_enriched: "{{ [] }}"
+
+- name: Set packages_enriched
+  set_fact:
+    packages_enriched: "{{ packages_enriched + [ zipped[0] | combine( { 'description': zipped[1].content | regex_search('Subtitle := \"[^\"]*') | replace('Subtitle := \"', ''), 'status': zipped[1].content | regex_search('Status := \"[^\"]*') | replace('Status := \"', ''), 'has_html_docu': zipped[2].status == 200, 'has_pdf_docu': zipped[3].status == 200 } ) ] }}"
+  loop: "{{ packages | zip(PackageInfo_responses.results, HTML_responses.results, PDF_responses.results) | list }}"
+  loop_control:
+    loop_var: zipped
+  no_log: true
+
+- name: Create depending package table
+  blockinfile:
+    path: ~/index.md
+    marker: "<!-- {mark} {{ meta_package.name }} USED_BY -->"
+    block: "{{ lookup('template', 'templates/homalg-project.github.io_used_by_table.j2') }}"

--- a/templates/homalg-project.github.io_subpackage_table.j2
+++ b/templates/homalg-project.github.io_subpackage_table.j2
@@ -1,0 +1,16 @@
+### Packages of [{{ meta_package.name }}](https://github.com/homalg-project/{{ meta_package.name }}):
+
+| Name | Description | Documentation | Status |
+| ---- | ----------- | ------------- | ------ |
+{% for package in packages_enriched %}
+| [{{ package.name }}](https://github.com/homalg-project/{{ meta_package.name }}/tree/master/{{ package.name }}) | {# -#}
+  {{ package.description }} | {# -#}
+  {%- if package.has_html_docu -%}
+    [![HTML stable documentation](https://img.shields.io/badge/HTML-stable-blue.svg)](https://homalg-project.github.io/{{ meta_package.name }}/{{ package.name }}/doc/chap0_mj.html)
+  {%- elif package.has_pdf_docu -%}
+    [![PDF development documentation](https://img.shields.io/badge/PDF-dev-blue.svg)](https://raw.githubusercontent.com/homalg-project/{{ meta_package.name }}/doc/{{ package.name }}.pdf)
+  {%- else -%}
+    Not available
+  {%- endif %} | {# -#}
+  {{ package.status }} |
+{% endfor %}

--- a/templates/homalg-project.github.io_used_by_table.j2
+++ b/templates/homalg-project.github.io_used_by_table.j2
@@ -1,0 +1,18 @@
+### Packages based on [{{ meta_package.name }}](https://github.com/homalg-project/{{ meta_package.name }}):
+
+| Name | Description | Documentation | Build Status | Code Coverage | Status |
+| ---- | ----------- | ------------- | ------------ | ------------- | ------ |
+{% for package in packages_enriched %}
+| [{{ package.name }}](https://github.com/homalg-project/{{ package.name }}) | {# -#}
+  {{ package.description }} | {# -#}
+  {%- if package.has_html_docu -%}
+    [![HTML stable documentation](https://img.shields.io/badge/HTML-stable-blue.svg)](https://homalg-project.github.io/{{ meta_package.name }}/{{ package.name }}/doc/chap0_mj.html)
+  {%- elif package.has_pdf_docu -%}
+    [![PDF development documentation](https://img.shields.io/badge/PDF-dev-blue.svg)](https://raw.githubusercontent.com/homalg-project/{{ meta_package.name }}/doc/{{ package.name }}.pdf)
+  {%- else -%}
+    Not available
+  {%- endif %} | {# -#}
+  [![Build Status](https://github.com/homalg-project/{{ package.name }}/workflows/Tests/badge.svg)](https://github.com/homalg-project/{{ package.name }}/actions?query=workflow%3ATests) | {# -#}
+  [![Code Coverage](https://codecov.io/gh/homalg-project/{{ package.name }}/branch/master/graph/badge.svg)](https://codecov.io/gh/homalg-project/{{ package.name }}) | {# -#}
+  {{ package.status }} |
+{% endfor %}


### PR DESCRIPTION
This is the first draft of generating an overview over all of our packages for homalg-project.github.io. The result can be seen here: https://github.com/zickgraf/FinSetsForCAP/blob/master/index.md (no, this has nothing to do with FinSetsForCAP, I'm only using it as a playground :D )

Unfortunately, GitHub does not generate a fallback icon if a package has no tests. Do we expect that all packages will have a GitHub Action `Tests` in the near future (even if it might do nothing for now)? If not, I can of course also detect this automatically, although this increases the likelihood of running into GitHub rate limits.