### PR TITLE
Add QPA as entity

### DIFF
--- a/templates/makedoc.g.j2
+++ b/templates/makedoc.g.j2
@@ -27,7 +27,7 @@ AutoDoc( rec(
         ),
     ),
     scaffold := rec(
-        entities := [ "homalg", "CAP" ],
+        entities := [ "homalg", "CAP"{% if package.needed_other_repositories is defined and "QPA2" in package.needed_other_repositories %}, "QPA"{% endif %} ],
     ),
 ) );
 

--- a/templates/makedoc_with_overfull_hbox_warnings.g.j2
+++ b/templates/makedoc_with_overfull_hbox_warnings.g.j2
@@ -38,7 +38,7 @@ AutoDoc( rec(
         ),
     ),
     scaffold := rec(
-        entities := [ "homalg", "CAP" ],
+        entities := [ "homalg", "CAP"{% if package.needed_other_repositories is defined and "QPA2" in package.needed_other_repositories %}, "QPA"{% endif %} ],
     ),
 ) );
 


### PR DESCRIPTION
Fixes #9

It is only added if `QPA2` is in `needed_other_repositories`.