### PR TITLE
Fix rendering of table of dependencies in MacDown

### DIFF
--- a/templates/README.md_HEADER.j2
+++ b/templates/README.md_HEADER.j2
@@ -14,8 +14,9 @@
 ### Dependencies
 
 To obtain current versions of all dependencies, clone the following repositories:
-|   | Repository | URL |
-| - | ---------- | --- |
+
+|    | Repository | URL |
+|--- | ---------- | --- |
 {% for repo in package.needed_other_repositories %}
 | {{ loop.index }}. | **{{ repo }}** | https://github.com/homalg-project/{{ repo }} |
 {% endfor %}


### PR DESCRIPTION
MacDown needs at least three dashes