### PR TITLE
Allow to specify repositories not part of homalg-project

### DIFF
--- a/templates/README.md_FOOTER.j2
+++ b/templates/README.md_FOOTER.j2
@@ -8,7 +8,7 @@ To obtain current versions of all dependencies, `git clone` (or `git pull` to up
 |    | Repository | git URL |
 |--- | ---------- | ------- |
 {% for repo in package.needed_other_repositories %}
-| {{ loop.index }}. | [**{{ repo }}**](https://github.com/homalg-project/{{ repo }}#readme) | https://github.com/homalg-project/{{ repo }}.git |
+| {{ loop.index }}. | [**{{ repo | basename }}**](https://github.com/{% if "/" not in repo %}homalg-project/{% endif %}{{ repo }}#readme) | https://github.com/{% if "/" not in repo %}homalg-project/{% endif %}{{ repo }}.git |
 {% endfor %}
 
 {% endif %}

--- a/templates/Tests.yml.j2
+++ b/templates/Tests.yml.j2
@@ -29,8 +29,8 @@ jobs:
           sudo apt update
           sudo apt install -y texlive-latex-extra{% for apt_package in (ci_ubuntu_additional_apt_packages | default([ ])) %} {{ apt_package }}{% endfor %}
           git clone --depth 1 https://github.com/gap-packages/AutoDoc.git
-        {%- for additional_package in ci_additional_repositories_enriched %}
-          git clone --depth 1 https://github.com/homalg-project/{{ additional_package }}.git
+        {%- for additional_repo in ci_additional_repositories_enriched %}
+          git clone --depth 1 https://github.com/{% if "/" not in additional_repo %}homalg-project/{% endif %}{{ additional_repo }}.git
         {%- endfor %}
           # set SOURCE_DATE_EPOCH for reproducible PDFs
           export SOURCE_DATE_EPOCH=0


### PR DESCRIPTION
If a repository listed under `needed_other_repositories` or `ci_additional_repositories` contains a `/`, we do not prepend `homalg-project` anymore.

@kamalsaleh Please test if this fixes your issue #61 by adding `gap-packages/NormalizInterface` to `needed_other_repositories` of `NConvex` :-)