### PR TITLE
Revert "make Toposes need CategoryConstructor"

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -178,9 +178,9 @@
           needed_other_repositories:
             - homalg_project
             - CAP_project
-            - CategoryConstructor
           tests_only_basic: true
         ci_additional_repositories:
+          - CategoryConstructor
           - SubcategoriesForCAP
           - Locales
           - ZariskiFrames


### PR DESCRIPTION
This reverts commit 23c63abdf2eef88f235342215b8bde0d94456077.