### PR TITLE
Bump required GAP version to 4.12

### DIFF
--- a/tasks/package_common.yml
+++ b/tasks/package_common.yml
@@ -70,7 +70,7 @@
   lineinfile:
     path: "{{ pkg_dir }}/{{ package.path }}/PackageInfo.g"
     regexp: "^  GAP := "
-    line: '  GAP := ">= 4.11.1",'
+    line: '  GAP := ">= 4.12.0",'
 
 - name: init.g header
   replace:


### PR DESCRIPTION
I would like to bump the required GAP version of our packages to 4.12 to be able to use the new features in GAP 4.12, to be able to drop workarounds for GAP 4.11, and because we do not test GAP 4.11 in the CI anymore, so things can break any time without us noticing anyway.

@mohamed-barakat Have you managed to update your installation to GAP 4.12?