### PR TITLE
Revert "remove CategoryConstructor from tests_additional_packages_to_load for Toposes"

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -207,6 +207,8 @@
           needed_other_repositories:
             - homalg_project
             - CAP_project
+          tests_additional_packages_to_load:
+            - CategoryConstructor
           tests_only_basic: true
         ci_additional_repositories:
           - CategoryConstructor


### PR DESCRIPTION
This reverts commit 6fbdd12ef5aa91de5d9c7b0454e1dd191b04da6d.

we need CategoryConstructor for (Co)limit it other packages