### PR TITLE
Add 'update-notebooks' to makefiles to simplify complying with recent code updates

### DIFF
--- a/tasks/meta_package.yml
+++ b/tasks/meta_package.yml
@@ -9,7 +9,7 @@
 
 - name: Set subpackages_enriched
   set_fact:
-    subpackages_enriched: "{{ subpackages_enriched + [ item | combine( { 'path': meta_package.name + '/' + item.name, 'repo': meta_package.name, 'docu_only': item.docu_only|default(false), 'GAPDoc_docu': item.GAPDoc_docu|default(false), 'tests_without_precompiled_code': item.tests_without_precompiled_code|default(false) } ) ] }}"
+    subpackages_enriched: "{{ subpackages_enriched + [ item | combine( { 'path': meta_package.name + '/' + item.name, 'repo': meta_package.name, 'docu_only': item.docu_only|default(false), 'GAPDoc_docu': item.GAPDoc_docu|default(false), 'tests_without_precompiled_code': item.tests_without_precompiled_code|default(false), 'has_notebooks': (pkg_dir | expanduser + '/' + meta_package.name + '/' + item.name + '/examples/notebooks/') is directory } ) ] }}"
   loop: "{{ subpackages }}"
   no_log: true
 

--- a/templates/makefile.j2
+++ b/templates/makefile.j2
@@ -50,6 +50,12 @@ test-notebooks:
 		rm modified_in out modified_out; \
 	done
 
+update-notebooks:
+	cd examples/notebooks/; \
+	for filename in *.ipynb; do \
+		jupyter nbconvert --ExecutePreprocessor.kernel_name=julia-$$(julia -e 'print(VERSION.major); print("."); print(VERSION.minor)') --ExecutePreprocessor.record_timing=False --to notebook --inplace --execute "$$filename"; \
+	done
+
 {% endif %}
 test-spacing:
 	# exit code 1 means no match, which is what we want here (exit code 2 signals an error)

--- a/templates/meta_package_makefile.j2
+++ b/templates/meta_package_makefile.j2
@@ -25,3 +25,11 @@ ci-test_{{ doc_package.name }}:
 	$(MAKE) -C {{ doc_package.name }} ci-test
 {% endfor %}
 
+################################
+update-notebooks:
+	for package in */; do \
+		if [ -f "$$package/makefile" ] && grep -q "update-notebooks:" "$$package/makefile"; then \
+			$(MAKE) -C $$package update-notebooks; \
+		fi \
+	done
+

--- a/templates/meta_package_makefile.j2
+++ b/templates/meta_package_makefile.j2
@@ -25,11 +25,16 @@ ci-test_{{ doc_package.name }}:
 	$(MAKE) -C {{ doc_package.name }} ci-test
 {% endfor %}
 
+{% if (doc_packages | map(attribute="has_notebooks")) is any %}
 ################################
-update-notebooks:
-	for package in */; do \
-		if [ -f "$$package/makefile" ] && grep -q "update-notebooks:" "$$package/makefile"; then \
-			$(MAKE) -C $$package update-notebooks; \
-		fi \
-	done
+update-notebooks:{% for doc_package in doc_packages %}{% if doc_package.has_notebooks %} update-notebooks_{{ doc_package.name }}{% endif %}{% endfor %}
 
+{% for doc_package in doc_packages %}
+{% if doc_package.has_notebooks %}
+
+update-notebooks_{{ doc_package.name }}:
+	$(MAKE) -C {{ doc_package.name }} update-notebooks
+{% endif %}
+{% endfor %}
+
+{% endif %}


### PR DESCRIPTION
e.g., when View/Display strings or the number of operations in a category are changed.