### PR TITLE
Escaped ${{ secrets.CODECOV_TOKEN }} using raw Jinja2 syntax ...

### DIFF
--- a/templates/Tests.yml.j2
+++ b/templates/Tests.yml.j2
@@ -101,7 +101,7 @@ jobs:
       - name: Upload code coverage
         if: github.event_name != 'schedule' && matrix.image == 'ghcr.io/homalg-project/gap-docker:latest'
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          CODECOV_TOKEN: ${{'{{ secrets.CODECOV_TOKEN }}'}}
         run: |
           cd {{ package.name }}
           ./dev/upload_codecov.sh


### PR DESCRIPTION
to ensure Ansible doesn't try to resolve 'secrets' as a variable.

resolves https://github.com/homalg-project/PackageJanitor/issues/177#event-18140712920