### PR TITLE
Remove `FinSets` from `tests_additional_packages_to_load`

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -745,8 +745,6 @@
           - name: GroupsAsCategoriesForCAP
             description: Groups as categories on one object
             tests_only_basic: true
-            tests_additional_packages_to_load:
-              - FinSetsForCAP
             has_subsplit: true
           - name: HomologicalAlgebraForCAP
             description: Homological algebra algorithms for CAP


### PR DESCRIPTION
Otherwise `FinSets` is loaded in the tests of the new package `GroupsAsCategoriesForCAP` (in `tst/100_LoadPackage.tst`) but `FinSets` is not available in the `CAP_project`-ci  --> error.