### PR TITLE
Adjust loading of `AdditiveClosuresForCAP`

### DIFF
--- a/files/.release
+++ b/files/.release
@@ -14,7 +14,7 @@ sed "s;Date := .*;Date := \"$(date -I)\",;" PackageInfo.g > PackageInfo.g.bak
 mv PackageInfo.g.bak PackageInfo.g
 
 # replace links to packages which are possibly referenced in the documentation, keep this in sync with `Tests.yml.j2`
-for package in CAP_project/CAP CAP_project/CompilerForCAP CAP_project/MonoidalCategories CAP_project/CartesianCategories CAP_project/FreydCategoriesForCAP HigherHomologicalAlgebra/ToolsForHigherHomologicalAlgebra homalg_project/homalg homalg_project/Modules CategoricalTowers/ToolsForCategoricalTowers CategoricalTowers/Toposes; do
+for package in CAP_project/CAP CAP_project/CompilerForCAP CAP_project/MonoidalCategories CAP_project/CartesianCategories CAP_project/AdditiveClosuresForCAP CAP_project/FreydCategoriesForCAP HigherHomologicalAlgebra/ToolsForHigherHomologicalAlgebra homalg_project/homalg homalg_project/Modules CategoricalTowers/ToolsForCategoricalTowers CategoricalTowers/Toposes; do
     
     # adjust links to other manuals
     # Note that we cannot use sed's `-i` option for in-place editing, as

--- a/site.yml
+++ b/site.yml
@@ -99,7 +99,6 @@
               - FinSetsForCAP
             tests_additional_packages_to_load:
               - IO_ForHomalg
-              - AdditiveClosuresForCAP
             tests_only_basic: true
             tests_without_precompiled_code: true
             has_subsplit: true
@@ -132,7 +131,6 @@
             tests_additional_packages_to_load:
               - ToolsForCategoricalTowers ## load before FinSetsForCAP
               - FinSetsForCAP       ## load before FreydCategoriesForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
             tests_only_basic: true
             has_subsplit: true
@@ -164,7 +162,6 @@
               - Digraphs
               - ToolsForCategoricalTowers ## load before FinSetsForCAP
               - FinSetsForCAP       ## load before FreydCategoriesForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - FunctorCategories
               - LazyCategories
@@ -219,7 +216,6 @@
               - ToolsForCategoricalTowers ## load before FinSetsForCAP
               - FinSetsForCAP       ## load before FreydCategoriesForCAP
               - Locales
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - IO_ForHomalg
             tests_only_basic: true
@@ -324,7 +320,6 @@
               - IO_ForHomalg
               - Digraphs
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - SubcategoriesForCAP
               - FunctorCategories
@@ -371,7 +366,6 @@
               - CAP_project
             tests_additional_packages_to_load:
               - IO_ForHomalg
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - FinSetsForCAP
               - Locales
@@ -393,7 +387,6 @@
               - Digraphs
               - Locales
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - SubcategoriesForCAP
             tests_only_basic: true
@@ -544,7 +537,6 @@
             \geometry{left=26mm,right=26mm}
           tests_additional_packages_to_load:
             - Toposes
-            - AdditiveClosuresForCAP
             - FreydCategoriesForCAP
             - FunctorCategories
             - json
@@ -578,7 +570,6 @@
               \usetikzlibrary{shapes,arrows,matrix}
             tests_additional_packages_to_load:
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - ModulePresentationsForCAP
               - Algebroids
@@ -594,7 +585,6 @@
             tests_additional_packages_to_load:
               - IO_ForHomalg
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - Algebroids
             tests_only_basic: true
@@ -605,7 +595,6 @@
             tests_additional_packages_to_load:
               - IO_ForHomalg
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - Algebroids
               - FunctorCategories
@@ -619,7 +608,6 @@
             tests_additional_packages_to_load:
               - IO_ForHomalg
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - Algebroids
             tests_only_basic: true
@@ -649,7 +637,6 @@
             description: Tools for the Higher Homological Algebra project
             tests_additional_packages_to_load:
               - FinSetsForCAP
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
             tests_only_basic: true
           - name: TriangulatedCategories
@@ -732,7 +719,6 @@
               \geometry{left=26mm,right=26mm}
             tests_additional_packages_to_load:
               - IO_ForHomalg
-              - AdditiveClosuresForCAP
               - FreydCategoriesForCAP
               - LinearAlgebraForCAP
               - RingsForHomalg

--- a/site.yml
+++ b/site.yml
@@ -293,7 +293,6 @@
               - homalg_project
               - CAP_project
             tests_additional_packages_to_load:
-              - AdditiveClosuresForCAP
               - LinearAlgebraForCAP
               - GeneralizedMorphismsForCAP
               - Algebroids


### PR DESCRIPTION
- Do not explicitly load `AdditiveClosuresForCAP` in presence of `FreydCategoriesForCAP`.
- Adjust `dev/.release` for `AdditiveClosuresForCAP`.

This is a draft for now, in case further adjustments are needed.