### PR TITLE
FunctorCategories: Rename ci target name in site.yml

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -480,7 +480,7 @@
             split_targets:
               - [PreSheavesOfCategoryPrecompiled]
               - [FinQuiversPrecompiled, FinBouquetsPrecompiled, FinReflexiveQuiversPrecompiled]
-              - [PreSheavesOfAlgebroidPrecompiled, PreSheavesOfAlgebroidFromDataTablesPrecompiled, PreSheavesOfFpCategoryInSkeletalFinSetsPrecompiled]
+              - [PreSheavesOfAlgebroidPrecompiled, PreSheavesOfAlgebroidFromDataTablesPrecompiled, PreSheavesOfFpCategoryDefinedByQuiverAlgebraInSkeletalFinSetsPrecompiled]
           - package: Algebroids
             split_targets:
               - [AdelmanCategoryVsQuiverRows, SnakeLemmaProof, SnakeLemmaProof2]


### PR DESCRIPTION
Replace PreSheavesOfFpCategoryInSkeletalFinSetsPrecompiled with PreSheavesOfFpCategoryDefinedByQuiverAlgebraInSkeletalFinSetsPrecompiled in split_targets

See: https://github.com/homalg-project/CategoricalTowers/pull/819#issuecomment-4781414937