### PR TITLE
GAP2Julia: Add Toposes to FpCategories deps

### DIFF
--- a/gap_to_julia/site.yml
+++ b/gap_to_julia/site.yml
@@ -351,6 +351,7 @@
             - ToolsForCategoricalTowers
             - QuotientCategories
             - FinSetsForCAP
+            - Toposes
           weak_dependencies:
           extras:
             - Test


### PR DESCRIPTION
Tools.gi@FpCategories requires ExactCoverWithGlobalElements which is defined in Toposes